### PR TITLE
New version: Highlight Automation Command 5.0.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,9 +7,10 @@ RUN apk add --no-cache \
     perl-xml-twig
 
 ENV CLI_NAME=Highlight-Automation-Command
+ENV CLI_VERSION=5.0.0
 ENV APP_DIR=/app/$CLI_NAME
 WORKDIR $APP_DIR
-RUN curl -sSL https://casthighlight.com/tools/cli/${CLI_NAME}.tar.gz \
+RUN curl -sSL https://casthighlight.com/tools/cli/${CLI_NAME}-${CLI_VERSION}.tar.gz \
     | tar xz -C /app
 COPY entrypoint.sh $APP_DIR
 

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -14,8 +14,6 @@ sourceDir=
 workingDir=
 login=
 password=
-tmp=
-dialog=
 
 shift # Remove "cast" from arguments
 
@@ -279,16 +277,6 @@ if [ -z "$workingDir" ]; then
 	flags+=(--workingDir "$workingDir")
 fi
 
-if [ -d "$sourceDir/tmp" ]; then
-	tmp=$(mktemp -p "$sourceDir" -u tmp.XXXXXX)
-	mv "$sourceDir/tmp" "$tmp"
-fi
-
-if [ -d "$sourceDir/dialog" ]; then
-	dialog=$(mktemp -p "$sourceDir" -u dialog.XXXXXX)
-	mv "$sourceDir/dialog" "$dialog"
-fi
-
 secrets=/secrets/.env
 if [ -z "$login" ] || [ -z "$password" ]; then
 	if [ -s "$secrets" ]; then
@@ -306,10 +294,4 @@ if [ -z "$login" ] || [ -z "$password" ]; then
 	fi
 fi
 
-java -jar HighlightAutomation.jar "${flags[@]}"
-
-rm -rf "$sourceDir/tmp"
-test -n "$tmp" && mv "$tmp" "$sourceDir/tmp"
-
-rm -rf "$sourceDir/dialog"
-test -n "$dialog" && mv "$dialog" "$sourceDir/dialog"
+exec java -jar HighlightAutomation.jar "${flags[@]}"


### PR DESCRIPTION
> Hi Tidal team! We built a new version of the command line that fixes the issue on dialog and tmp folders. 
> dialog folder has been moved to HLTemporary (--workingDir) and tmp is created where you launch the JAR (e.g. c:\highlight\commandline\tmp)