### PR TITLE
Update CAST Highlight Tool version

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     perl-xml-libxml
 
 ENV CLI_NAME=Highlight-Automation-Command
-ENV CLI_VERSION=5.3.5
+ENV CLI_VERSION=5.3.17
 ENV APP_DIR=/app/$CLI_NAME
 WORKDIR $APP_DIR
 RUN curl -sSL https://doc.casthighlight.com/tools/cli/${CLI_NAME}.tar.gz \


### PR DESCRIPTION
This PR introduces the following change:

- Update CAST Highlight Tool version to v5.3.17

See https://doc.casthighlight.com/product-tutorials-third-party-tools/automated-code-scan-command-line/ for details