### PR TITLE
Correct command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You should see a notification in Slack, #tidal-tools, regarding a successful ima
 ## Usage
 
 ```
-$ docker build -t cast-highlight alpine
+$ docker build -t cast-highlight .
 
 $ docker run --rm \
   -v /path/to/sources:/src \


### PR DESCRIPTION
corrects the args in the build command docs. current one returns an error. The new one works as expected