### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG CLI_NAME=Highlight-Automation-Command
-ARG CLI_VERSION=5.3.82
+ARG CLI_VERSION=5.4.0
 
 FROM alpine AS builder
 RUN apk add --no-cache curl


### PR DESCRIPTION
This PR updates CAST Highlight Tool CLI Dockerfile to version 5.4.0:

> The version 5.4.0 of the command line is available. It adds CloudReady patterns for C++.

— https://twitter.com/HighlightProdUp/status/1488090718681899008